### PR TITLE
Conserve memory

### DIFF
--- a/OpenfMRI_ds000117/02-plot_preprocessing.py
+++ b/OpenfMRI_ds000117/02-plot_preprocessing.py
@@ -31,6 +31,7 @@ ECG_ch_name = data['ECG_ch_name']
 EoG_ch_name = data['EoG_ch_name']
 variance = data['variance']
 reject = data['reject']
+down_sfreq = data['down_sfreq']
 
 ###############################################################################
 # Then, we create our workflow and specify the `base_dir` which tells
@@ -67,7 +68,7 @@ from ephypype.pipelines.preproc_meeg import create_pipeline_preproc_meeg  # noqa
 preproc_workflow = create_pipeline_preproc_meeg(
     data_path, l_freq=l_freq, h_freq=h_freq,
     variance=variance, ECG_ch_name=ECG_ch_name, EoG_ch_name=EoG_ch_name,
-    data_type=data_type)
+    data_type=data_type, down_sfreq=down_sfreq)
 
 ###############################################################################
 # We then connect the nodes two at a time. First, we connect the two outputs
@@ -98,4 +99,4 @@ main_workflow.write_graph(graph2use='colored')  # colored
 main_workflow.config['execution'] = {'remove_unnecessary_outputs': 'false'}
 
 # Run workflow locally on 1 CPU
-main_workflow.run(plugin='LegacyMultiProc', plugin_args={'n_procs': NJOBS})
+main_workflow.run(plugin='LegacyMultiProc', plugin_args={'n_procs': 1})

--- a/OpenfMRI_ds000117/03-extract_events.py
+++ b/OpenfMRI_ds000117/03-extract_events.py
@@ -16,7 +16,7 @@ import os.path as op
 
 from mne.parallel import parallel_func
 
-from params import data_path
+from params import data_path, NJOBS
 
 ###############################################################################
 # this is the dir where the cleaned raw data was saved
@@ -39,7 +39,7 @@ def run_events_concatenate(subject_id):
         run_fname = op.join(ica_dir % (run, subject),
                             'ica', 'run_%02d_sss_filt_ica.fif' % run)
         print(run_fname)
-        raw = mne.io.read_raw_fif(run_fname, preload=True)
+        raw = mne.io.read_raw_fif(run_fname, preload=False)
         mask = 4096 + 256  # mask for excluding high order bits
         events = mne.find_events(raw, stim_channel='STI101',
                                  consecutive='increasing', mask=mask,
@@ -69,5 +69,5 @@ def run_events_concatenate(subject_id):
 ###############################################################################
 # Let us make the script parallel across subjects
 # Here we use fewer N_JOBS to prevent potential memory problems
-parallel, run_func, _ = parallel_func(run_events_concatenate, n_jobs=2)
+parallel, run_func, _ = parallel_func(run_events_concatenate, n_jobs=NJOBS)
 parallel(run_func(subject_id) for subject_id in range(1, 20))

--- a/OpenfMRI_ds000117/params_inverse.json
+++ b/OpenfMRI_ds000117/params_inverse.json
@@ -13,7 +13,7 @@
     "condition": ["face/famous", "scrambled", "face/unfamiliar"],
     "events_file": "*_sss_filt_ica-raw-eve.fif",
     "tmin": -0.2,
-    "tmax": 2.9,
+    "tmax": 1.0,
     "trans_fname": "*-trans.fif",
     "spacing": "oct-6",
     "snr": 3.0,

--- a/OpenfMRI_ds000117/params_preprocessing.json
+++ b/OpenfMRI_ds000117/params_preprocessing.json
@@ -1,6 +1,7 @@
 {
     "l_freq": 0.1,
     "h_freq": 40,
+	"down_sfreq": 300,
     "ECG_ch_name": "EEG063",
     "EoG_ch_name": "EEG061, EEG062",
     "variance": 0.999,


### PR DESCRIPTION
The pipeline currently uses a huge amount of memory, because it unnecessarily preloads all of the raw data for a subject, does not downsample after lowpass filtering and cuts unnecessarily large epochs (-0.2 to 3 seconds, while you plot at 0.17 seconds). This PR aims to substantially reduce the required memory to run the pipeline.